### PR TITLE
closes 39 switch to ruff for linting instead of pylint

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -10,18 +10,17 @@ tasks:
   format:
     desc: Format the code
     cmds:
-      - python -m poetry run black mpcforces_extractor
+      - python -m poetry run ruff format mpcforces_extractor
 
   lint:
     desc: Lint the code
     cmds:
-      - python -m poetry run black --check mpcforces_extractor
       - |
         python -m poetry run flake8 mpcforces_extractor \
            --show-source \
            --statistics \
            --count
-      - python -m poetry run pylint mpcforces_extractor
+      - python -m poetry run ruff check mpcforces_extractor
 
   test:
     desc: Run tests

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -15,6 +15,7 @@ tasks:
   lint:
     desc: Lint the code
     cmds:
+      - python -m poetry run black --check mpcforces_extractor
       - |
         python -m poetry run flake8 mpcforces_extractor \
            --show-source \

--- a/mpcforces_extractor/datastructure/rigids.py
+++ b/mpcforces_extractor/datastructure/rigids.py
@@ -50,7 +50,6 @@ class MPC:
 
         # add the forces for each part
         for part_id, node_ids in self.part_id2node_ids.items():
-
             forces[part_id] = [0, 0, 0, 0, 0, 0]
 
             for node_id in node_ids:

--- a/mpcforces_extractor/datastructure/test_rigids.py
+++ b/mpcforces_extractor/datastructure/test_rigids.py
@@ -22,7 +22,6 @@ class TestRigids(unittest.TestCase):
         self.assertEqual(mpc.dofs, "123")
 
     def test_sum_forces_by_connected_parts(self):
-
         node_id2force = {
             1: [1, 1, 1, 0, 0, 0],
             2: [2, 2, 2, 0, 0, 0],

--- a/mpcforces_extractor/force_extractor.py
+++ b/mpcforces_extractor/force_extractor.py
@@ -58,7 +58,6 @@ class MPCForceExtractor:
         self.part_id2connected_node_ids = Element.get_part_id2node_ids_graph()
 
         for mpc in self.reader.rigid_elements:
-
             part_id2forces = mpc.sum_forces_by_connected_parts(
                 self.node_id2forces, self.part_id2connected_node_ids
             )

--- a/mpcforces_extractor/reader/modelreaders.py
+++ b/mpcforces_extractor/reader/modelreaders.py
@@ -111,7 +111,6 @@ class FemFileReader:
         """
         elements_found = False
         for i, _ in enumerate(self.file_content[self.endGridLine :]):
-
             line = self.file_content[i]
 
             if line.strip().startswith("+") and elements_found:

--- a/mpcforces_extractor/reader/mpcforces_reader.py
+++ b/mpcforces_extractor/reader/mpcforces_reader.py
@@ -37,7 +37,6 @@ class MPCForcesReader:
                     not self.file_content[i].startswith("---")
                     and not self.file_content[i].strip() == ""
                 ):
-
                     line = self.file_content[i]
 
                     # take the first 8 characters as the node id

--- a/mpcforces_extractor/reader/test_modelreaders.py
+++ b/mpcforces_extractor/reader/test_modelreaders.py
@@ -7,7 +7,6 @@ from mpcforces_extractor.datastructure.loads import Force, Moment
 
 
 class TestFemFileReader(unittest.TestCase):
-
     # the __read_lines method is a private method, so we need to mock it and return propper file_content
     @patch(
         "mpcforces_extractor.reader.modelreaders.FemFileReader._FemFileReader__read_lines"

--- a/mpcforces_extractor/test_force_extractor.py
+++ b/mpcforces_extractor/test_force_extractor.py
@@ -4,7 +4,6 @@ from mpcforces_extractor.force_extractor import MPCForceExtractor
 
 
 class TestFMPCForceExtractor(unittest.TestCase):
-
     def test_init(self):
         """
         Test the init method. Make sure all variables are set correctly (correct type)

--- a/mpcforces_extractor/writer/summary_writer.py
+++ b/mpcforces_extractor/writer/summary_writer.py
@@ -35,7 +35,6 @@ class SummaryWriter:
         This method adds the lines for each MPC element to the summary
         """
         for mpc, part_id2forces in mpc_element2part2forces.items():
-
             self.add_mpc_line(mpc, part_id2forces)
 
     def add_mpc_line(self, mpc, part_id2forces):

--- a/poetry.lock
+++ b/poetry.lock
@@ -2583,6 +2583,33 @@ pygments = ">=2.13.0,<3.0.0"
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "ruff"
+version = "0.6.8"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.6.8-py3-none-linux_armv6l.whl", hash = "sha256:77944bca110ff0a43b768f05a529fecd0706aac7bcce36d7f1eeb4cbfca5f0f2"},
+    {file = "ruff-0.6.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:27b87e1801e786cd6ede4ada3faa5e254ce774de835e6723fd94551464c56b8c"},
+    {file = "ruff-0.6.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:cd48f945da2a6334f1793d7f701725a76ba93bf3d73c36f6b21fb04d5338dcf5"},
+    {file = "ruff-0.6.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:677e03c00f37c66cea033274295a983c7c546edea5043d0c798833adf4cf4c6f"},
+    {file = "ruff-0.6.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9f1476236b3eacfacfc0f66aa9e6cd39f2a624cb73ea99189556015f27c0bdeb"},
+    {file = "ruff-0.6.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f5a2f17c7d32991169195d52a04c95b256378bbf0de8cb98478351eb70d526f"},
+    {file = "ruff-0.6.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5fd0d4b7b1457c49e435ee1e437900ced9b35cb8dc5178921dfb7d98d65a08d0"},
+    {file = "ruff-0.6.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8034b19b993e9601f2ddf2c517451e17a6ab5cdb1c13fdff50c1442a7171d87"},
+    {file = "ruff-0.6.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6cfb227b932ba8ef6e56c9f875d987973cd5e35bc5d05f5abf045af78ad8e098"},
+    {file = "ruff-0.6.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ef0411eccfc3909269fed47c61ffebdcb84a04504bafa6b6df9b85c27e813b0"},
+    {file = "ruff-0.6.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:007dee844738c3d2e6c24ab5bc7d43c99ba3e1943bd2d95d598582e9c1b27750"},
+    {file = "ruff-0.6.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ce60058d3cdd8490e5e5471ef086b3f1e90ab872b548814e35930e21d848c9ce"},
+    {file = "ruff-0.6.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1085c455d1b3fdb8021ad534379c60353b81ba079712bce7a900e834859182fa"},
+    {file = "ruff-0.6.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:70edf6a93b19481affd287d696d9e311388d808671bc209fb8907b46a8c3af44"},
+    {file = "ruff-0.6.8-py3-none-win32.whl", hash = "sha256:792213f7be25316f9b46b854df80a77e0da87ec66691e8f012f887b4a671ab5a"},
+    {file = "ruff-0.6.8-py3-none-win_amd64.whl", hash = "sha256:ec0517dc0f37cad14a5319ba7bba6e7e339d03fbf967a6d69b0907d61be7a263"},
+    {file = "ruff-0.6.8-py3-none-win_arm64.whl", hash = "sha256:8d3bb2e3fbb9875172119021a13eed38849e762499e3cfde9588e4b4d70968dc"},
+    {file = "ruff-0.6.8.tar.gz", hash = "sha256:a5bf44b1aa0adaf6d9d20f86162b34f7c593bfedabc51239953e446aefc8ce18"},
+]
+
+[[package]]
 name = "scipy"
 version = "1.14.1"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -2926,4 +2953,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "6f0c18161532ffb9804ca30c6da749647009d36e04da5dd6f969d5161abbc188"
+content-hash = "f94904b236fe5529a8d31e66f961e65739286939b4e76957e9977887e431c5e2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,23 @@ mkdocs-material = "^9.5.38"
 mkdocstrings = {extras = ["python"], version = "^0.26.1"}
 mkdocs-coverage = "^1.1.0"
 twine = "^5.1.1"
+ruff = "^0.6.8"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "B"]
+ignore = ["E501"]
+unfixable = ["B"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["E402"]
+"**/{tests,docs,tools}/*" = ["E402"]
+
+[tool.ruff.format]
+#quote-style = "single"
 
 [tool.poetry.scripts]
 mpcforces-extractor = "mpcforces_extractor.cli.__main__:app"


### PR DESCRIPTION
In this pull request I changed the linter / formatter to be ruff instead of black / pylint.

Things I am not sure about:
- I left flake8 in there - is that a bad thing? 
- The output of ruff check is minimal - is this bad?

